### PR TITLE
Enhancement/use native pybind11 numpy conversions

### DIFF
--- a/src/pymurtree/OptimalDecisionTreeClassifier.py
+++ b/src/pymurtree/OptimalDecisionTreeClassifier.py
@@ -54,7 +54,8 @@ class OptimalDecisionTreeClassifier:
     
 
     def fit(self,
-            x, y,
+            x: np.ndarray, 
+            y: np.ndarray,
             time: int = None,
             max_depth: int = None,
             max_num_nodes: int = None,
@@ -110,7 +111,7 @@ class OptimalDecisionTreeClassifier:
             x = standardize_to_dtype_int32(x) # These are required otherwise the model will not work and test will fail
             y = standardize_to_dtype_int32(y)
             if x.shape[0] == y.shape[0]:
-                    self.__params.arr = np.concatenate((y.reshape(-1,1), x), axis=1)
+                    arr = np.concatenate((y.reshape(-1,1), x), axis=1)
             else: 
                 raise ValueError('x and y have different number of rows')
             
@@ -143,7 +144,7 @@ class OptimalDecisionTreeClassifier:
 
         # Initialize solver (call cpp Solver class constructor)
         if self.__solver is None:
-            self.__solver = lib.Solver(self.__params.arr,
+            self.__solver = lib.Solver(arr,
                                        self.__params.time,
                                        self.__params.max_depth,
                                        self.__params.max_num_nodes,
@@ -159,7 +160,7 @@ class OptimalDecisionTreeClassifier:
                                        self.__params.duplicate_factor)
         
         # Creates the tree that will be used for predictions
-        self.__tree = self.__solver.solve(self.__params.arr,
+        self.__tree = self.__solver.solve(arr,
                                           self.__params.time,
                                           self.__params.max_depth,
                                           self.__params.max_num_nodes,

--- a/src/pymurtree/bindings.cpp
+++ b/src/pymurtree/bindings.cpp
@@ -13,28 +13,6 @@
 namespace py = pybind11;
 using namespace MurTree;
 
-// This function is used to convert a numpy array to a vector of booleans
-std::vector<bool> NdarrayToVector(const py::array_t<bool>& arr) {
-    auto buffer = arr.request();
-    bool* ptr = (bool*) buffer.ptr;
-    std::vector<bool> boolean_vector(ptr, ptr + buffer.size);
-    return boolean_vector;
-}
-
-// This function is used to convert a numpy array to a vector of vectors
-std::vector<std::vector<int>> NumpyToVectors(py::array_t<int, py::array::c_style>& arr) {
-    auto buf = arr.request();
-    int* ptr = (int*) buf.ptr;
-    int nrows = buf.shape[0];
-    int ncols = buf.shape[1];
-
-    std::vector<std::vector<int>> vectors(nrows);
-    for (int i = 0; i < nrows; i++) {
-        vectors[i] = std::vector<int>(ptr + i * ncols, ptr + (i+1) * ncols);
-    }
-    return vectors;
-}
-
 // This function is used to convert a numpy array to a vector of vectors holding feature vector binary types
 // that were defined in the murtree library
 std::vector<std::vector<FeatureVectorBinary>> ReadDataDL(const std::vector<std::vector<int>>& vector, int duplicate_instances_factor)
@@ -128,21 +106,6 @@ PYBIND11_MODULE(lib, m) {
     m.def("_read_data_dl", &FileReader::ReadDataDL, py::arg("filename"), py::arg("duplicate_instances_factor"), 
           "Reads file and returns feature vectors");
 
-    // We use this function to construct the function that turns vectors into feature vectors which is
-    // feature vectors is a murtree defined type
-    m.def("_nparray_to_vectors", &NumpyToVectors, py::arg("np_array"), "Converts numpy array to vector of vectors");
-    // Read data coming as a numpy array that is then converted to a vector of vectors
-    // To do that we need to use the numpy_to_vectors function and then
-    // pass the result to the ReadDataDL function
-    m.def("_nparray_to_feature_vectors", [](py::array_t<int,  py::array::c_style>& arr, 
-                                            int duplicate_instances_factor) -> std::vector<std::vector<FeatureVectorBinary>> {
-        // We don't return the result as this is only needed to pass the data to the solver
-        // This function is meant to be private and will only be used to pass data to the solver like so:
-        return ReadDataDL(NumpyToVectors(arr), duplicate_instances_factor);
-    }, py::arg("np_array"), py::arg("duplicate_instances_factor"), 
-          "Reads file and returns feature vectors");
-    
-
     py::class_<ParameterHandler> parameter_handler(m, "ParameterHandler");
 
     // Expose the create parameters function to python so that we can create a parameter handler object from python
@@ -153,29 +116,17 @@ PYBIND11_MODULE(lib, m) {
             py::arg("node_selection"), py::arg("feature_ordering"), py::arg("random_seed"),
             py::arg("cache_type"), py::arg("duplicate_factor"), "Creates a parameter handler object");
 
-    
+
     // The SolverResult returns a tree with the methods we need for the predict method of the python wrapper
     py::class_<SolverResult> solver_result(m, "SolverResult");
 
-    solver_result.def("_classify", [](const SolverResult &solverresult, const py::array_t<bool>&  arr){
-        return solverresult.decision_tree_->Classify(new MurTree::FeatureVectorBinary(NdarrayToVector(arr), 0));
-    });
-
-    // This runs the classify method on each data point to get a vector of classifications
-    solver_result.def("_predict", [](const SolverResult &solverresult, py::array_t<int, py::array::c_style>& arr){
-        // Define the structure of the numpy array that we will return
-        auto buf = arr.request();
-        int* ptr = (int*) buf.ptr;
-        int nrows = buf.shape[0];
-        int ncols = buf.shape[1];
-
-        std::vector<int> predictions(nrows);
-        // Here we make the classification for all rows in the data
-        for (int i = 0; i < nrows; i++) {
-            predictions[i] = solverresult.decision_tree_->Classify(new MurTree::FeatureVectorBinary(std::vector<bool>(ptr + i * ncols, ptr + (i+1) * ncols), 0));
+    solver_result.def("_predict", [](const SolverResult &solverresult, const std::vector<std::vector<int>> arr){
+        std::vector<int> predictions;
+        for (int i = 0; i < arr.size(); i++) {
+            MurTree::FeatureVectorBinary row({std::vector<bool>(arr[i].begin(), arr[i].end())}, i);
+            predictions.push_back(solverresult.decision_tree_->Classify(&row));
         }
-        // Predictions are returned as a numpy array
-        return py::array_t<int>(nrows, predictions.data());
+        return py::array_t<int>(predictions.size(), predictions.data()); 
     });
 
     solver_result.def("misclassification_score", [](const SolverResult &solverresult) {
@@ -190,12 +141,11 @@ PYBIND11_MODULE(lib, m) {
         return solverresult.decision_tree_->NumNodes();
     });
     
-    
     // Bindings for the MurTree::Solver class
     py::class_<Solver> solver(m, "Solver");
     
     // Bindings for the MurTree::Solver constructor
-    solver.def(py::init([](py::array_t<int, py::array::c_style>& arr, // The numpy array containing the data
+    solver.def(py::init([](std::vector<std::vector<int>> arr, // The numpy array containing the data
     unsigned int time, unsigned int max_depth,
     unsigned int max_num_nodes, float sparse_coefficient, bool verbose,
     bool all_trees, bool incremental_frequency, bool similarity_lower_bound,
@@ -214,7 +164,7 @@ PYBIND11_MODULE(lib, m) {
         }
         // Construct the Solver object
         // We turn the numpy array into a vector of feature vectors before
-        return new Solver(ph, ReadDataDL(NumpyToVectors(arr), duplicate_factor));
+        return new Solver(ph, ReadDataDL(arr, duplicate_factor));
 
     }), py::keep_alive<0, 1>());
 
@@ -237,12 +187,6 @@ PYBIND11_MODULE(lib, m) {
         return solver.Solve(ph);
     });
     
-
-
-    solver_result.def("tree_nodes", [](const SolverResult &solverresult) {
-        return solverresult.decision_tree_->NumNodes();
-    });
-
     // Bindings for the ExportTree class
     solver_result.def("export_text", [](const SolverResult &solverresult, std::string filepath) {
         ExportTree::exportText(solverresult.decision_tree_, filepath);

--- a/tests/test_optimal_decision_tree_classifier.py
+++ b/tests/test_optimal_decision_tree_classifier.py
@@ -68,16 +68,20 @@ def expected_predict_output():
 
 def test_predict(decision_tree, x_train_data, expected_predict_output):
     predict_output = decision_tree.predict(x_train_data)
+    # check that predict_output is a numpy array
+    print(predict_output)
+    print(type(predict_output))
+    assert predict_output is not None
+    assert isinstance(predict_output, np.ndarray)
     assert (predict_output == expected_predict_output).all()
-
 
 def test_predict_empty_input(decision_tree):
     # Ensure that an error or exception is raised when no input data is provided
     with pytest.raises(Exception):
-        decision_tree.predict([])
+        decision_tree._predict([])
 
 def test_predict_invalid_input(decision_tree):
     # Ensure that an error or exception is raised when invalid input data is provided
     # ...
     with pytest.raises(Exception):
-        decision_tree.predict(invalid_input)
+        decision_tree._predict(invalid_input)

--- a/tests/test_readdata.py
+++ b/tests/test_readdata.py
@@ -1,4 +1,11 @@
+'''
+Decription of test cases for readdata.py as user stories and acceptance criteria
 
+Story: As a user I want to read data from a file so that I can use it for training and testing
+AC: The file is written in DL format see the readme for details
+AC: The file is read and converted to a numpy array  (x, y) where x is the feature vectors and y is the labels
+AC: Features are binary values and labels are integers
+'''
 import pytest
 import pandas as pd
 import numpy as np
@@ -40,28 +47,6 @@ def test_read_from_file():
     assert type(x) == pd.core.frame.DataFrame
     assert type(y) == pd.core.series.Series
     
-
-def test_np_to_vectors(dl_x_y):
-    ''' Test that the numpy array is converted to a list of vectors'''
-
-    x = dl_x_y[0].to_numpy().astype(np.int32)
-    cpp_vectors = lib._nparray_to_vectors(x)
-
-    assert cpp_vectors is not None
-    assert type(cpp_vectors) == list
-    assert len(cpp_vectors) == x.shape[0]
-    assert type(cpp_vectors[0][0] == int)
-
-def test_nparray_to_feature_vectors(dl_data_sample):
-    ''' Test that the numpy array is converted to a list of feature vectors'''
-
-    feature_vectors = lib._nparray_to_feature_vectors(dl_data_sample, 1)
-
-    assert feature_vectors is not None
-    assert type(feature_vectors) == list
-    assert type(feature_vectors[0]== lib.FeatureVectorBinary)
-    assert len(feature_vectors) == dl_data_sample.shape[0] - 1
-
 def test_compare_feature_vectors(dl_from_file):
     ''' Test that we get exactly the same feature vectors from the file and from the numpy array'''
     feature_vectors_from_file = lib._read_data_dl(TRAIN_DATA, 1)
@@ -72,14 +57,3 @@ def test_compare_feature_vectors(dl_from_file):
     feature_vectors = lib._nparray_to_feature_vectors(dl_from_file, 1)
     assert len(feature_vectors[0]) == len(feature_vectors_from_file[0])
     assert len(feature_vectors) == len(feature_vectors_from_file)
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Hi @yiquintero with this last commit the original tests are passing after reusing pybind11 buitin conversions.
I had to keep the method to convert from np array to feature vectors. See line 122 of `./src/pymurtree/bindings.cpp`.
